### PR TITLE
Fixed crash when Authenticating in new Java versions.

### DIFF
--- a/src/main/java/org/openwilma/kotlin/parsers/WilmaJSONParser.kt
+++ b/src/main/java/org/openwilma/kotlin/parsers/WilmaJSONParser.kt
@@ -7,8 +7,21 @@ import java.text.SimpleDateFormat
 import java.util.*
 
 object WilmaJSONParser {
+
+    class SkipThrowableStrategy: ExclusionStrategy {
+
+        override fun shouldSkipField(f: FieldAttributes): Boolean {
+            return f.declaringClass == java.lang.Throwable::class.java
+        }
+
+        override fun shouldSkipClass(clazz: Class<*>?): Boolean {
+            return false
+        }
+    }
+
     // Custom Gson instance with custom date format and date handling
     val gson: Gson = GsonBuilder().setDateFormat("yyyy-MM-dd HH:mm")
+        .setExclusionStrategies(SkipThrowableStrategy())
         .registerTypeAdapter(Date::class.java, object: JsonDeserializer<Date> {
         val format = SimpleDateFormat("yyyy-MM-dd HH:mm")
         val formatWithoutDate = SimpleDateFormat("yyyy-MM-dd")


### PR DESCRIPTION
```java.lang.Throwable``` is no longer allowed to be accessed with reflections (in java 17+), unless the launch arguments are modified, which is not something that should be needed to be done for the library to not crash.

Of course, this also means that now we can no longer de-serialize Throwables.


Here is the original stacktrace

```
com.google.gson.JsonIOException: Failed making field 'java.lang.Throwable#detailMessage' accessible; either increase its visibility or write a custom TypeAdapter for its declaring type.
	at com.google.gson.internal.reflect.ReflectionHelper.makeAccessible(ReflectionHelper.java:38)
	at com.google.gson.internal.bind.ReflectiveTypeAdapterFactory.getBoundFields(ReflectiveTypeAdapterFactory.java:286)
	at com.google.gson.internal.bind.ReflectiveTypeAdapterFactory.create(ReflectiveTypeAdapterFactory.java:130)
	at com.google.gson.Gson.getAdapter(Gson.java:556)
	at com.google.gson.internal.bind.ReflectiveTypeAdapterFactory.createBoundField(ReflectiveTypeAdapterFactory.java:160)
	at com.google.gson.internal.bind.ReflectiveTypeAdapterFactory.getBoundFields(ReflectiveTypeAdapterFactory.java:294)
	at com.google.gson.internal.bind.ReflectiveTypeAdapterFactory.create(ReflectiveTypeAdapterFactory.java:130)
	at com.google.gson.Gson.getAdapter(Gson.java:556)
	at com.google.gson.Gson.fromJson(Gson.java:1226)
	at com.google.gson.Gson.fromJson(Gson.java:1137)
	at com.google.gson.Gson.fromJson(Gson.java:1047)
	at com.google.gson.Gson.fromJson(Gson.java:1014)
	at org.openwilma.kotlin.methods.AuthenticationKt$getSessionId$2$1.onResponse(Authentication.kt:30)
	at org.openwilma.kotlin.clients.WilmaHttpClient.getRequest(WilmaHttpClient.kt:92)
	at org.openwilma.kotlin.clients.WilmaHttpClient.getRequest$default(WilmaHttpClient.kt:77)
	at org.openwilma.kotlin.methods.AuthenticationKt.getSessionId(Authentication.kt:28)
	at org.openwilma.kotlin.methods.AuthenticationKt.signIn(Authentication.kt:48)
	at org.openwilma.kotlin.OpenWilma$Companion.signInToWilma(OpenWilma.kt:41)
	at org.openwilma.kotlin.OpenWilma$Companion.signInToWilma$default(OpenWilma.kt:41)
```